### PR TITLE
minor fixes to references formatting

### DIFF
--- a/vignettes/bibliography.bib
+++ b/vignettes/bibliography.bib
@@ -106,7 +106,7 @@
 	Year = {2017}}
 
 @manual{Finak2011,
-	Author = {Greg Finak and Mike Jiang},
+	Author = {Finak, Greg and Jiang, Mike},
 	Journal = {R package version 3.24.4},
 	Title = {{flowWorkspace}: infrastructure for representing and interacting with the gated cytometry},
 	Year = {2011}}
@@ -151,7 +151,7 @@
 
 @article{Gu2016,
     title = {Complex heatmaps reveal patterns and correlations in multidimensional genomic data},
-    author = {Zuguang Gu and Roland Eils and Matthias Schlesner},
+    author = {Gu, Zuguang and Eils, Roland and Schlesner, Matthias},
     journal = {Bioinformatics},
     doi = {10.1093/bioinformatics/btw313},
     year = {2016},
@@ -489,8 +489,8 @@
 	Year = {2019}}
 
 @article{Weber2019,
-	Author = {Lukas M. Weber and Charlotte Soneson},
-	Journal = {R package version 1.2.0},
+	Author = {Weber, Lukas M and Robinson, Mark D and Soneson, Charlotte},
+	Journal = {R package version 1.3.9},
 	Title = {{HDCytoData}: benchmark datasets for high-dimensional cytometry in {Bioconductor} object formats},
 	Year = {2019}}
 


### PR DESCRIPTION
Couple of minor edits to formatting of references (e.g. the references to HDCytoData within the main text were showing my initials, due to the way the .bib entry was formatted)